### PR TITLE
Vary the render cache by the value of the parent_bundle variable

### DIFF
--- a/includes/paragraph.inc
+++ b/includes/paragraph.inc
@@ -17,7 +17,10 @@ function gla_core_theme_preprocess_paragraph(&$variables) {
   $paragraphHelper = \Drupal::service('gla_core_profile.paragraph_helper');
 
   if ($paragraphHelper->getParentParagraph($paragraph)) {
+    // Add a cache tag for the parent entity to prevent issues where the
+    // parent_bundle variable is incorrectly set due to caching.
     $variables['parent_bundle'] = $paragraphHelper->getParentParagraph($paragraph)->bundle();
+    $variables['#cache']['tags'][] = 'parent_entity_bundle:' . $variables['parent_bundle'];
   }
 
   switch ($paragraph->bundle()) {


### PR DESCRIPTION
I have a feeling that the `parent_bundle` variable that I added to all Paragraphs via a preprocess might not be reliable unless we also vary the render cache by it, so I've added some missing cache metadata.