### PR TITLE
DERP-894 - Create a new stacking context for the media control compon…

### DIFF
--- a/components/01-atoms/media-control/media-control.twig
+++ b/components/01-atoms/media-control/media-control.twig
@@ -7,6 +7,7 @@
   .addClass([
     'media-control',
     'u-group',
+    'u-isolate',
     'u-relative u-overflow-hidden',
     'u-flex u-items-center u-justify-center',
     'u-transition-all',


### PR DESCRIPTION
…ent to prevent z-index issues

We use https://tailwindcss.com/docs/isolation (https://developer.mozilla.org/en-US/docs/Web/CSS/isolation) to create a new stacking context to avoid the issue in the demo where the media-control component (the play/pause button) remained above the Media item component even once the video had started to play.