### PR TITLE
DERP-629: Improve check for NVM

### DIFF
--- a/scripts/build-theme.sh
+++ b/scripts/build-theme.sh
@@ -15,10 +15,11 @@ if [ "$DRUPAL_ENVIRONMENT" != 'docker' ] && [ "$SKIP_COMPOSER_SCRIPT_THEME_BUILD
   echo "To make the change permanent add the variable to your .bashrc file or equivalent."
   echo ""
 
-  # Set the Node version based on .nvmrc - if NVM is installed
-  if [ ! -z $NVM_DIR ] && [ -f $NVM_DIR/nvm.sh ]; then
-    . $NVM_DIR/nvm.sh && nvm install && nvm use
-  fi
+  # Source the NVM script if the nvm command isn't available
+  [ ! $(command -v nvm) ] && [ ! -z $NVM_DIR ] && [ -f $NVM_DIR/nvm.sh ] && . $NVM_DIR/nvm.sh
+
+  # Attempt to install and use the version of node in the .nvmrc file
+  nvm install && nvm use
 
   current_node_version=$(node -v || node --version)
   target_node_version=$(cat .nvmrc)


### PR DESCRIPTION
The previous check for NVM was failing due to the fact that the nvm script returns an exit code of 3 when sourced, which was
preventing the `nvm install` and `nvm use` commands from executing.

Instead, we attempt to source the `nvm.sh` script if the `nvm` command does not exist, and then we run `nvm install` and `nvm use` regardless.

Note that even if these commands fail, that doesn't mean that we should not proceed. There is an existing check for Node version, which will determine whether the script should continue.

https://london.atlassian.net/browse/DERP-629

[ Partial fix for DERP-629 ]